### PR TITLE
Add proxy support via config-option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,16 @@ svnUltimate.commands.update( '/home/user/checkout',
 		revision: 33050,		// provide --revision to commands that accept it
 		depth: "empty",			// provide --depth to commands that accept it
 		ignoreExternals: true,	// provide --ignore-externals to commands that accept it
-		params: [ '-m "Commit comment"' ] // extra parameters to pass
+		params: [ '-m "Commit comment"' ], // extra parameters to pass
+		'config-option': [
+			'servers:global:http-proxy-host=proxy.someProxy.com',
+			'servers:global:http-proxy-port=8080',
+		] // provide --config-option to commands that accept it.  Use an array for multiple config options
 	},
 	function( err ) {
 		console.log( "Update complete" );
 	} );
-	
+
 ```
 
 Utility methods

--- a/index.js
+++ b/index.js
@@ -45,6 +45,15 @@ var execute = function( cmd, options, callback ) {
 		if ( typeof options.password === 'string' ) {
 			cmd += ' --password=' + options.password;
 		}
+		if ( options['config-option'] ) {
+			if ( Array.isArray(options['config-option']) ) {
+				options['config-option'].forEach(option => {
+					cmd += ' --config-option=' + option;
+				});
+			} else {
+				cmd += ' --config-option=' + options['config-option'];
+			}
+		}
 	}
 	if ( options.params ) {
 		cmd += ' ' + options.params.join( " " );


### PR DESCRIPTION
Added support for --config-option.

Since multiple --config-option flags are allowed, i.e. when setting proxy with both host and port, but the data structure is a javascript object not capable of duplicate keys, I made this type accept either a single string or an array of strings (when multiple flags are desired).