### PR TITLE
Check correct value for case

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,7 +147,7 @@ var addExtraOptions = function( validOptionsArray, options, addRevProp ) {
 					}
 					break;
 				case 'ignoreExternals':
-					if ( options.depth ) {
+					if ( options.ignoreExternals ) {
 						options.params.push('--ignore-externals');
 					}
 					break;


### PR DESCRIPTION
It looks like this may have just been a copy-paste error. I believe that the ignoreExternals should be checked instead of the depth.